### PR TITLE
fix: inject --model flag into tool_command when model param is specified

### DIFF
--- a/issues/mcp-dogfooding-2026-04-08.md
+++ b/issues/mcp-dogfooding-2026-04-08.md
@@ -1,0 +1,95 @@
+# Shoal MCP Dogfooding Issues - 2026-04-08
+
+Source: Dogfooding session fixing Pisces issues via Shoal + Gemma 4 31B
+Related: `~/pantheon/tools/pisces/issues/mcp-dogfooding-2026-04-07.md`
+
+---
+
+## Issue S1: Worktrees don't get `node_modules` — need auto install
+
+**Severity:** High
+**Status:** Open
+
+**Problem:** When Shoal creates a git worktree for branch isolation, the worktree has no `node_modules`. Bun/npm packages aren't tracked by git, so the worktree starts with zero dependencies. Pisces (and any Node/Bun tool) immediately crashes on launch:
+
+```
+error: Cannot find package 'handlebars'
+```
+
+**Repro:**
+1. `shoal new -t pisces -n my-fix .` (creates worktree)
+2. Pisces launches in the worktree → crash
+
+**Expected:** Shoal should detect the package manager (bun.lock → `bun install`, package-lock.json → `npm install`, etc.) and auto-run install after creating the worktree. Could be a template config option like `post_create = "bun install"`.
+
+**Workaround:** Manually `bun install` in each worktree before launching the tool.
+
+---
+
+## Issue S2: `shoal new` lacks `--model` flag
+
+**Severity:** Medium
+**Status:** Open
+
+**Problem:** There's no way to pass a model to the spawned agent from the CLI. The only option is using a template with a hardcoded model (e.g., `gemma-test` template has `--model openrouter/google/gemma-4-31b-it:free`). But this requires creating a template for every model you want to use.
+
+**Repro:**
+1. `shoal new --help` — no `--model` flag listed
+2. No way to say `shoal new -t pisces --model openrouter/google/gemma-4-31b-it .`
+
+**Expected:** `shoal new --model <provider/model>` should pass the model to the tool's CLI command. Pisces supports `--model` on its CLI already.
+
+**Workaround:** Use templates with hardcoded models, or send the command manually via `send_keys`.
+
+---
+
+## Issue S3: Template pane commands not always applied
+
+**Severity:** Medium
+**Status:** Open
+
+**Problem:** The `gemma-test` template has `command = "{tool_command} --model openrouter/google/gemma-4-31b-it:free"` but the session launched with just `fish` as the command. The tool command wasn't applied to the tmux pane.
+
+**Repro:**
+1. Create session with `gemma-test` template via `shoal new -t pisces --template gemma-test`
+2. Session starts with `fish` shell, not `pisces --model ...`
+
+**Expected:** Template's command should be sent to the tmux pane after creation.
+
+**Workaround:** Manually send the command via `send_keys`.
+
+---
+
+## Issue S4: Worktree creation on dirty/unmerged HEAD succeeds silently
+
+**Severity:** Medium
+**Status:** Open
+
+**Problem:** The main checkout had an incomplete merge in progress. Shoal created worktrees from HEAD anyway, but HEAD was in an inconsistent state — some files existed on disk but weren't in the git tree (unmerged). This caused missing files in worktrees.
+
+**Repro:**
+1. Start a `git merge` with conflicts (don't resolve)
+2. `shoal new -t pisces -n my-fix .` — worktree created from incomplete HEAD
+
+**Expected:** Shoal should either refuse to create a worktree when the working tree is dirty/unmerged, or warn the user.
+
+---
+
+## Issue S5: Free-tier rate limits cause frequent model fallbacks
+
+**Severity:** Low
+**Status:** By design
+
+**Problem:** Using `openrouter/google/gemma-4-31b-it:free` on OpenRouter's free tier hits rate limits quickly (429 errors). Pisces falls back through its model chain, ending up on `minimax/minimax-m2.7` or `google/gemma-4-26b-a4b-it` instead.
+
+**Not a Shoal bug** — this is expected behavior for free-tier models. Documenting for awareness.
+
+---
+
+## Fix Session Summary
+
+- **Session:** `fix-p1-model-enforce` using `gemma-test` template
+- **Actual model used:** `google/gemma-4-26b-a4b-it` (fell back from `gemma-4-31b-it:free`)
+- **Pisces fixes delivered:** 3 commits merged to `main`
+- **Shoal issues found:** 5 (4 open, 1 by design)
+- **Workaround burden:** Manual `bun install` + manual `send_keys` for each session = ~2 min overhead per session

--- a/src/shoal/services/lifecycle.py
+++ b/src/shoal/services/lifecycle.py
@@ -896,7 +896,11 @@ async def create_session_lifecycle(
         ValueError: invalid session name.
     """
     template_name = template_cfg.name if template_cfg else ""
-    logger.info("[%s] create: starting (tool=%s)", session_name, tool)
+    logger.info("[%s] create: starting (tool=%s, model=%s)", session_name, tool, model or "default")
+
+    # 0b. Inject --model into tool_command if model is specified and not already present
+    if model and "--model" not in tool_command:
+        tool_command = f"{tool_command} --model {model}"
 
     # 1. Create DB row
     try:
@@ -1137,6 +1141,7 @@ async def fork_session_lifecycle(
     worktree_name: str = "",
     mcp_servers: list[str] | None = None,
     parent_id: str = "",
+    model: str = "",
 ) -> SessionState:
     """Fork a session with full rollback on failure.
 
@@ -1146,7 +1151,13 @@ async def fork_session_lifecycle(
     Raises:
         SessionExistsError, TmuxSetupError, StartupCommandError, ValueError.
     """
-    logger.info("[%s] fork: starting (tool=%s)", session_name, source_tool)
+    logger.info(
+        "[%s] fork: starting (tool=%s, model=%s)", session_name, source_tool, model or "default"
+    )
+
+    # Inject --model into tool_command if model is specified and not already present
+    if model and "--model" not in tool_command:
+        tool_command = f"{tool_command} --model {model}"
 
     # 1. Create DB row
     try:

--- a/src/shoal/services/lifecycle.py
+++ b/src/shoal/services/lifecycle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shlex
 import subprocess
 from collections import defaultdict
@@ -864,6 +865,34 @@ async def _apply_template_git_config_async(
 # ---------------------------------------------------------------------------
 
 
+def _inject_model_arg(command: str, model: str | None) -> str:
+    """Inject ``--model`` into a tool command string if not already present.
+
+    Uses :func:`shlex.quote` to prevent shell injection when the model
+    string is eventually typed into a tmux pane via ``send_keys``.
+
+    If *command* already contains ``--model`` as a standalone flag, the
+    explicit *model* parameter is **not** appended and a warning is logged
+    so that template-baked models take precedence without silent overrides.
+
+    Args:
+        command: The tool command string (e.g. ``"pisces"``).
+        model: Model identifier to inject (e.g. ``"z-ai/glm-5"``).
+
+    Returns:
+        The command with ``--model`` appended, or *command* unchanged.
+    """
+    if not model:
+        return command
+    # Check for --model as a standalone flag (not part of a longer flag like --model-path)
+    if re.search(r"(?:^|\s)--model(?:=|\s|$)", command):
+        logger.warning(
+            "tool_command already contains --model; skipping injection of model=%s", model
+        )
+        return command
+    return f"{command} --model {shlex.quote(model)}"
+
+
 async def create_session_lifecycle(
     *,
     session_name: str,
@@ -881,7 +910,7 @@ async def create_session_lifecycle(
     tags: list[str] | None = None,
     dreamer_config: DreamerConfig | None = None,
     coordinator_config: CoordinatorConfig | None = None,
-    model: str = "",
+    model: str | None = None,
 ) -> SessionState:
     """Create a session with full rollback on failure.
 
@@ -898,9 +927,8 @@ async def create_session_lifecycle(
     template_name = template_cfg.name if template_cfg else ""
     logger.info("[%s] create: starting (tool=%s, model=%s)", session_name, tool, model or "default")
 
-    # 0b. Inject --model into tool_command if model is specified and not already present
-    if model and "--model" not in tool_command:
-        tool_command = f"{tool_command} --model {model}"
+    # Inject --model flag into tool_command when model is specified
+    tool_command = _inject_model_arg(tool_command, model)
 
     # 1. Create DB row
     try:
@@ -912,7 +940,7 @@ async def create_session_lifecycle(
             branch_name,
             tags=tags or [],
             template_name=template_name,
-            model=model,
+            model=model or "",
         )
     except ValueError as exc:
         if "already exists" in str(exc) or "collides" in str(exc):
@@ -1141,12 +1169,28 @@ async def fork_session_lifecycle(
     worktree_name: str = "",
     mcp_servers: list[str] | None = None,
     parent_id: str = "",
-    model: str = "",
+    model: str | None = None,
 ) -> SessionState:
     """Fork a session with full rollback on failure.
 
     Same pattern as :func:`create_session_lifecycle` but for forks.
     Fixes the missing startup-command rollback in the previous fork path.
+
+    Args:
+        session_name: Name for the new session.
+        source_tool: Tool identifier from the source session.
+        source_path: Git root of the source session.
+        source_branch: Branch name in the source session.
+        wt_path: Path to the new git worktree.
+        work_dir: Working directory inside the worktree.
+        new_branch: Branch name for the fork.
+        tool_command: Command to launch the tool (e.g. ``"pisces"``).
+        startup_commands: Extra shell commands to run after tool launch.
+        template_cfg: Optional template configuration to apply.
+        worktree_name: Display name for the worktree.
+        mcp_servers: MCP servers to provision.
+        parent_id: ID of the parent session.
+        model: Model to inject into the tool command (e.g. ``"z-ai/glm-5"``).
 
     Raises:
         SessionExistsError, TmuxSetupError, StartupCommandError, ValueError.
@@ -1155,9 +1199,8 @@ async def fork_session_lifecycle(
         "[%s] fork: starting (tool=%s, model=%s)", session_name, source_tool, model or "default"
     )
 
-    # Inject --model into tool_command if model is specified and not already present
-    if model and "--model" not in tool_command:
-        tool_command = f"{tool_command} --model {model}"
+    # Inject --model flag into tool_command when model is specified
+    tool_command = _inject_model_arg(tool_command, model)
 
     # 1. Create DB row
     try:

--- a/src/shoal/services/mcp_shoal_server.py
+++ b/src/shoal/services/mcp_shoal_server.py
@@ -582,7 +582,7 @@ async def create_session_tool(
             template_cfg=template_cfg,
             worktree_name=worktree or "",
             mcp_servers=mcp_servers,
-            model=model or "",
+            model=model,
         )
     except SessionExistsError as e:
         raise ToolError(str(e)) from e
@@ -687,7 +687,7 @@ async def fork_session_tool(
             worktree_name=name,
             mcp_servers=mcp_servers,
             parent_id=source_session.id,
-            model=model or "",
+            model=model,
         )
     except SessionExistsError as e:
         raise ToolError(str(e)) from e
@@ -801,7 +801,7 @@ async def spawn_team_tool(
                 worktree_name=worker_name,
                 mcp_servers=resolved_mcp,
                 parent_id=source_session.id,
-                model=model or "",
+                model=model,
             )
         except (SessionExistsError, TmuxSetupError, StartupCommandError, ValueError) as e:
             logger.warning("[spawn_team] worker %s failed: %s", worker_name, e)

--- a/src/shoal/services/mcp_shoal_server.py
+++ b/src/shoal/services/mcp_shoal_server.py
@@ -633,6 +633,7 @@ async def fork_session_tool(
     prompt: str | None = None,
     template: str | None = None,
     mcp_servers: list[str] | None = None,
+    model: str | None = None,
 ) -> dict[str, Any]:
     """Fork a session into a new worker.
 
@@ -642,6 +643,7 @@ async def fork_session_tool(
         prompt: Initial prompt to send to the worker after startup.
         template: Template name to apply to the worker session.
         mcp_servers: MCP servers to provision for the worker.
+        model: Model to use for the forked session (e.g., "z-ai/glm-5"). Overrides tool default.
     """
     from shoal.core.config import ensure_dirs, load_config, load_tool_config
     from shoal.core.state import find_by_name, get_session
@@ -685,6 +687,7 @@ async def fork_session_tool(
             worktree_name=name,
             mcp_servers=mcp_servers,
             parent_id=source_session.id,
+            model=model or "",
         )
     except SessionExistsError as e:
         raise ToolError(str(e)) from e
@@ -730,6 +733,7 @@ async def spawn_team_tool(
     workers: list[dict[str, Any]],
     template: str | None = None,
     mcp_servers: list[str] | None = None,
+    model: str | None = None,
 ) -> dict[str, Any]:
     """Spawn multiple worker sessions.
 
@@ -739,6 +743,7 @@ async def spawn_team_tool(
                  'prompt' (str) to send after startup.
         template: Template to apply to all workers.
         mcp_servers: MCP servers to provision for all workers.
+        model: Model to use for all workers (e.g., "z-ai/glm-5"). Overrides tool default.
     """
     from shoal.core.config import ensure_dirs, load_config, load_tool_config
     from shoal.core.message_bus import send_message
@@ -796,6 +801,7 @@ async def spawn_team_tool(
                 worktree_name=worker_name,
                 mcp_servers=resolved_mcp,
                 parent_id=source_session.id,
+                model=model or "",
             )
         except (SessionExistsError, TmuxSetupError, StartupCommandError, ValueError) as e:
             logger.warning("[spawn_team] worker %s failed: %s", worker_name, e)


### PR DESCRIPTION
## Problem
The `model` parameter passed to `create_session`, `fork_session`, and `spawn_team` MCP tools was stored in the DB but never injected into the tool launch command. Workers spawned with `model='gemma-4-31b'` still launched with the default model (Sonnet 4.6), incurring unnecessary API costs.

## Fix
- New `_inject_model_arg()` helper: DRY, shell-safe (`shlex.quote`), logs warning when skipping injection
- `create_session_lifecycle`: uses helper, `model` now `str | None`
- `fork_session_lifecycle`: add `model` param, uses helper, full docstring
- `fork_session_tool` / `spawn_team_tool`: accept and forward `model`
- Regex-based `--model` detection instead of naive string containment

## Security Review
- `shlex.quote()` prevents command injection via model strings
- Warns when model is silently skipped due to template override

Fixes #15